### PR TITLE
Configure Gemini env vars for Vercel deployments

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,21 @@
+# Deployment Notes
+
+## Required Environment Variables
+
+Vercel deployments for this project rely on the API configuration found in [`apps/api/.env.example`](apps/api/.env.example).
+Set the following variables in the Vercel dashboard (or via `vercel env`) for the **Production**, **Preview**, and **Development** environments:
+
+- `GEMINI_API_KEY` (required) – API key used by the AI sourcing coach endpoints when calling Google Gemini.
+- `GEMINI_MODEL` (optional) – Model identifier passed to Gemini. Defaults to `gemini-2.5-flash-preview-05-20`; override when you need a different model version.
+
+The repository's [`vercel.json`](vercel.json) is configured to expect secrets named `gemini_api_key` and `gemini_model`. Create or update the secrets and link them to each environment, for example:
+
+```bash
+vercel secrets add gemini_api_key <your-api-key>
+vercel secrets add gemini_model gemini-2.5-flash-preview-05-20
+vercel env add GEMINI_API_KEY production < gemini_api_key
+vercel env add GEMINI_MODEL production < gemini_model
+# repeat for preview and development as needed
+```
+
+After the variables are added, redeploy the project so the API functions can read the new configuration.

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,23 @@
 {
   "installCommand": "npm install",
   "buildCommand": "npm run build --workspace web",
-  "outputDirectory": "apps/web/dist"
+  "outputDirectory": "apps/web/dist",
+  "production": {
+    "env": {
+      "GEMINI_API_KEY": "@gemini_api_key",
+      "GEMINI_MODEL": "@gemini_model"
+    }
+  },
+  "preview": {
+    "env": {
+      "GEMINI_API_KEY": "@gemini_api_key",
+      "GEMINI_MODEL": "@gemini_model"
+    }
+  },
+  "development": {
+    "env": {
+      "GEMINI_API_KEY": "@gemini_api_key",
+      "GEMINI_MODEL": "@gemini_model"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- configure the Vercel project to inject GEMINI_API_KEY and GEMINI_MODEL for production, preview, and development builds
- add deployment notes documenting the Gemini environment variables and how to seed them in Vercel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a28e8ebc8330b98d1196f6878001